### PR TITLE
Add broadcast settings buttons to modal and i18n

### DIFF
--- a/src/bottomBar/BottomBar.js
+++ b/src/bottomBar/BottomBar.js
@@ -18,14 +18,15 @@ export const BottomBar = () => {
   if (!showBars || isFullscreen) return null;
 
   return (
-    <View style={styles.container}>
-      <View
-        style={[
-          styles.buttons,
-          baseStyles.panelBackground,
-          { bottom: insets.bottom },
-        ]}
-      >
+    <View
+      style={[
+        styles.container,
+        { bottom: Math.max(insets.bottom, 16) },
+        { left: insets.left + 8 },
+        { right: insets.right + 8 },
+      ]}
+    >
+      <View style={[styles.buttons, baseStyles.panelBackground]}>
         <MuteBtn />
         <CammuteBtn />
         <QuestionBtn />
@@ -40,9 +41,8 @@ export const BottomBar = () => {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    left: 8,
-    right: 8,
-    bottom: 16,
+    left: 30,
+    right: 30,
     alignItems: 'center',
   },
   buttons: {

--- a/src/bottomBar/MoreBtn.js
+++ b/src/bottomBar/MoreBtn.js
@@ -11,8 +11,7 @@ export const MoreBtn = () => {
   const { toggleMoreModal, moreModal } = useUiActions();
 
   return (
-    <Pressable onPress={toggleMoreModal} style={bottomBar.btn}>
-      <View style={bottomBar.moreSelBtn}>
+    <Pressable onPress={toggleMoreModal} style={bottomBar.moreSelBtn}>
         <BottomBarIconWithText
           iconName={moreModal ? 'close' : 'more-vert'}
           text="close"
@@ -24,7 +23,6 @@ export const MoreBtn = () => {
           showtext={false}
         />
         <ChatCounter />
-      </View>
     </Pressable>
   );
 };

--- a/src/bottomBar/moreBtns/BroadcastMuteBtn.js
+++ b/src/bottomBar/moreBtns/BroadcastMuteBtn.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable } from 'react-native';
+// import Icon from 'react-native-vector-icons/MaterialIcons';
+import BottomBarIconWithText from '../../settings/BottomBarIconWithTextAnimated';
+import { useShidurStore } from '../../zustand/shidur';
+import { bottomBar } from '../helper';
+
+export const BroadcastMuteBtn = () => {
+  const { isMuted, setIsMuted } = useShidurStore();
+  const toggleMute = () => setIsMuted();
+  const { t } = useTranslation();
+  
+
+  return (
+    <Pressable onPress={toggleMute} style={bottomBar.btn}>
+      <BottomBarIconWithText
+        iconName="volume-up"
+        text={t('bottomBar.broadcastsound')}
+        extraStyle={
+          isMuted
+            ? ['toggle_off', 'toggle_off_icon']
+            : ['toggle_on_alt2', 'toggle_on_icon_alt2']
+        }
+        showtext={true}
+        direction="vertical"
+      />
+    </Pressable>
+  );
+};

--- a/src/bottomBar/moreBtns/ChatBtn.js
+++ b/src/bottomBar/moreBtns/ChatBtn.js
@@ -18,7 +18,7 @@ export const ChatBtn = () => {
     <>
       <Pressable onPress={handlePress} style={bottomBar.btn}>
         <BottomBarIconWithText
-          iconName="forum"
+          iconName="chat"
           text={t('bottomBar.chat')}
           extraStyle={['rest', 'resticon']}
           showtext={true}

--- a/src/bottomBar/moreBtns/SubtitleBtn.js
+++ b/src/bottomBar/moreBtns/SubtitleBtn.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable } from 'react-native';
+import BottomBarIconWithText from '../../settings/BottomBarIconWithTextAnimated';
+import { useSubtitleStore } from '../../zustand/subtitle';
+import { bottomBar } from '../helper';
+
+export const SubtitleBtn = () => {
+  const { toggleIsOpen, lastMsg, isOpen } = useSubtitleStore();
+  const { t } = useTranslation();
+  // if (!lastMsg?.slide) return null;
+
+  const toggle = () => toggleIsOpen();
+  return (
+    <Pressable onPress={toggle} style={bottomBar.btn}>
+      <BottomBarIconWithText
+        iconName="subtitles"
+        text={t('bottomBar.broadcastsubtitles')}
+        extraStyle={
+          !isOpen
+            ? ['toggle_off', 'toggle_off_icon']
+            : ['toggle_on_alt2', 'toggle_on_icon_alt2']
+        }
+        showtext={true}
+        direction="vertical"
+      />
+    </Pressable>
+  );
+};

--- a/src/bottomBar/moreBtns/TranslationBtn.js
+++ b/src/bottomBar/moreBtns/TranslationBtn.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable } from 'react-native';
+import BottomBarIconWithText from '../../settings/BottomBarIconWithTextAnimated';
+import { useShidurStore } from '../../zustand/shidur';
+import { bottomBar } from '../helper';
+
+export const TranslationBtn = () => {
+  const toggleIsOriginal = useShidurStore(state => state.toggleIsOriginal);
+  const audio = useShidurStore(state => state.audio);
+
+  const { t } = useTranslation();
+  const isOriginal = audio?.key === 'wo_original';
+
+  const toggle = () => toggleIsOriginal();
+  return (
+    <Pressable onPress={toggle} style={bottomBar.btn}>
+      <BottomBarIconWithText
+        iconName="translate"
+        text={t('bottomBar.broacasttranslation')}
+        extraStyle={
+          isOriginal
+            ? ['toggle_off', 'toggle_off_icon']
+            : ['toggle_on_alt2', 'toggle_on_icon_alt2']
+        }
+        showtext={true}
+        direction="vertical"
+      />
+    </Pressable>
+  );
+};

--- a/src/components/ButtonsPaneModal.js
+++ b/src/components/ButtonsPaneModal.js
@@ -18,9 +18,12 @@ import { BottomBar } from '../bottomBar/BottomBar';
 import { GroupsBtn } from '../bottomBar/moreBtns/GroupsBtn';
 import { HideSelfBtn } from '../bottomBar/moreBtns/HideSelfBtn';
 import { ShidurBtn } from '../bottomBar/moreBtns/ShidurBtn';
+import { SubtitleBtn } from '../bottomBar/moreBtns/SubtitleBtn';
+import { TranslationBtn } from '../bottomBar/moreBtns/TranslationBtn';
 import { baseStyles } from '../constants';
 import { useInitsStore } from '../zustand/inits';
 import { useUiActions } from '../zustand/uiActions';
+import { BroadcastMuteBtn } from '../bottomBar/moreBtns/BroadcastMuteBtn';
 
 const ButtonsPaneModal = () => {
   const { t } = useTranslation();
@@ -38,7 +41,12 @@ const ButtonsPaneModal = () => {
         supportedOrientations={['portrait', 'landscape']}
       >
         <TouchableWithoutFeedback onPress={toggleMoreModal}>
-          <View style={styles.modalContainer}>
+          <View
+            style={[
+              styles.modalContainer,
+              { paddingBottom: Math.max(insets.bottom, 16) + 80 + 16 },
+            ]}
+          >
             <BottomBar />
             <View
               style={[
@@ -67,6 +75,33 @@ const ButtonsPaneModal = () => {
                       <HideSelfBtn />
                     </View>
                   </View>
+                </View>
+              </View>
+              <View style={styles.buttonsSection}>
+                <Text style={[baseStyles.text, styles.text]} numberOfLines={1}>
+                  {t('bottomBar.broadcastsettings')}
+                </Text>
+                <View style={styles.buttonsBlock}>
+                  <View style={styles.buttonsRow}>
+                    <View style={styles.button_33}>
+                      <TranslationBtn />
+                    </View>
+                    <View style={styles.button_33}>
+                      <SubtitleBtn />
+                    </View>
+                    <View style={styles.button_33}>
+                      <BroadcastMuteBtn />
+                    </View>
+                  </View>
+
+                  {/* <View style={styles.buttonsRow}>
+                    <View style={styles.button_50}>
+                      <GroupsBtn />
+                    </View>
+                    <View style={styles.button_50}>
+                      <HideSelfBtn />
+                    </View>
+                  </View> */}
                 </View>
               </View>
               <View style={styles.buttonsSection}>
@@ -131,7 +166,7 @@ export const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-end',
     backgroundColor: 'rgba(0, 0, 0, 0.8)',
-    paddingBottom: 80 + 16 + 16, // BottomBar height + marginBottom + extra
+    // paddingBottom: 80 + 16 + 16, // BottomBar height + marginBottom + extra
   },
   paneWrapper: {
     // padding: 16,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -50,6 +50,10 @@
     "leave": "Leave room",
     "chat": "Chat",
     "show": "Show",
+    "broadcastsettings": "Broadcast Settings",
+    "broacasttranslation": "Translation",
+    "broadcastsubtitles": "Subtitles",
+    "broadcastsound": "Audio",
     "open": "Open"
   },
   "shidur": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -38,12 +38,16 @@
   },
   "bottomBar": {
     "vote": "Vote",
-    "shidur": "Translation",
+    "shidur": "Transmisión",
     "self": "Hide my video",
     "kliOlami": "Kli Olamy tens",
     "leave": "Leave room",
     "chat": "Chat",
     "show": "Mostrar",
+    "broadcastsettings": "Configuración de transmisión",
+    "broacasttranslation": "Traducción",
+    "broadcastsubtitles": "Subtitles",
+    "broadcastsound": "Audio",
     "open": "Abrir"
   },
   "shidur": {

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -40,11 +40,15 @@
   "bottomBar": {
     "vote": "הצבעה",
     "shidur": "שידור",
-    "self": "להסתיר את הווידאו שלי",
-    "kliOlami": "Kli Olamy tens",
+    "self": "וידאו שלי",
+    "kliOlami": "הכלי העולמי",
     "leave": "עזוב את החדר",
     "chat": "צ'אט",
     "show": "הצג",
+    "broadcastsettings": "הגדרות שידור",
+    "broacasttranslation": "תרגום",
+    "broadcastsubtitles": "כתוביות",
+    "broadcastsound": "שמע",
     "open": "פתח"
   },
   "shidur": {

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -46,6 +46,10 @@
     "leave": "Покинуть комнату",
     "chat": "Чат",
     "show": "Показать",
+    "broadcastsettings": "Настройки трансляции",
+    "broacasttranslation": "Перевод",
+    "broadcastsubtitles": "Субтитры",
+    "broadcastsound": "Аудио",
     "open": "Открыть"
   },
   "shidur": {

--- a/src/shidur/Shidur.js
+++ b/src/shidur/Shidur.js
@@ -19,13 +19,13 @@ import { useSettingsStore } from '../zustand/settings';
 import { useShidurStore } from '../zustand/shidur';
 import { useUiActions } from '../zustand/uiActions';
 import { FullscreenBtn } from './FullscreenBtn';
-import { MuteBtn } from './MuteBtn';
+// import { MuteBtn } from './MuteBtn';
 import OptionsBtn from './OptionsBtn';
-import { OriginalSwitch } from './OriginalSwitch';
+// import { OriginalSwitch } from './OriginalSwitch';
 import { PlayPauseBtn } from './PlayPauseBtn';
 import { PlayPauseOverlay } from './PlayPauseOverlay';
 import Subtitle from './Subtitle';
-import { SubtitleBtn } from './SubtitleBtn';
+// import { SubtitleBtn } from './SubtitleBtn';
 
 const NAMESPACE = 'Shidur';
 
@@ -75,12 +75,12 @@ const Shidur = () => {
             <View style={styles.toolbar}>
               <View style={styles.toolbarBtnsGroup}>
                 <PlayPauseBtn />
-                <MuteBtn />
-                <OriginalSwitch />
+                {/* <MuteBtn /> */}
+                {/* <OriginalSwitch /> */}
               </View>
 
               <View style={styles.toolbarBtnsGroup}>
-                <SubtitleBtn />
+                {/* <SubtitleBtn /> */}
                 <OptionsBtn />
                 <FullscreenBtn />
               </View>


### PR DESCRIPTION
Introduced new buttons for broadcast translation, subtitles, and audio mute in the ButtonsPaneModal, with corresponding components and i18n strings for English, Spanish, Hebrew, and Russian. Updated BottomBar and MoreBtn layout, and refactored Shidur.js to remove old toolbar buttons in favor of the new modal-based controls.